### PR TITLE
Patch 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ribn",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Topl's Wallet",
 	"main": "index.js",
 	"directories": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.2.0+1
+version: 0.2.1+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Ribn",
   "description": "Web wallet for Topl Blockchain",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
   },


### PR DESCRIPTION
## Description

This branch adds bug fixes and UI/UX patch improvements to 0.2 redesign. Including:
- Adds empty state for wallet home, mint and send asset pages for when there are no assets in the wallet
- Corrects the font weight throughout the app to actually use normal, medium and bold 
- Onboarding action buttons are now the correct size as per the designs
- Removes the navigation animation in Chrome desktop (only animates in mobile)
- Makes a bunch of text formatting changes in onboarding pages to better fit with designs
- Resizes icons to better fit with designs
- Resize modal title so the text fits onto one line
- Optimizes login screen on Chrome to look more like the designs
- Reduces the height of the bottom action button 
- And more

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-   [ X ] Manually tested across mobile & chrome