### PR TITLE
Remaining tweaks for RC 0.3

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -33,7 +33,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/lib/constants/network_utils.dart
+++ b/lib/constants/network_utils.dart
@@ -25,6 +25,6 @@ class NetworkUtils {
   static Map<int, String> networkUrls = {
     valhallaId: 'https://vertx.topl.services/valhalla/$projectId',
     toplNetId: 'https://vertx.topl.services/mainnet/$projectId',
-    privateId: 'http://35.226.176.100:9085'
+    privateId: 'http://$privateIP:9085'
   };
 }

--- a/lib/constants/network_utils.dart
+++ b/lib/constants/network_utils.dart
@@ -7,6 +7,7 @@ class NetworkUtils {
   static const String toplNet = 'toplnet';
   static const String valhalla = 'valhalla';
   static const String private = 'private';
+  static const String privateIP  = '34.123.57.233';
   static int toplNetId = constants.networkRegistry[toplNet]!;
   static int valhallaId = constants.networkRegistry[valhalla]!;
   static int privateId = constants.networkRegistry[private]!;

--- a/lib/middlewares/login_middleware.dart
+++ b/lib/middlewares/login_middleware.dart
@@ -51,6 +51,10 @@ void Function(Store<AppState> store, AttemptLoginAction action, NextDispatcher n
       }
       // initialize hd wallet on success
       next(InitializeHDWalletAction(toplExtendedPrivateKey: toplExtendedPrvKeyUint8List));
+
+      //Generate Initial addresses for every network
+      next(GenerateInitialAddressesAction());
+
       action.completer.complete(true);
     } catch (e) {
       action.completer.complete(false);

--- a/lib/platform/mobile/genus_config.dart
+++ b/lib/platform/mobile/genus_config.dart
@@ -1,8 +1,9 @@
 import 'package:grpc/grpc.dart';
+import 'package:ribn/constants/network_utils.dart';
 
 class PlatformGenusConfig {
   static ClientChannel channel = ClientChannel(
-    '35.226.176.100',
+    NetworkUtils.privateIP,
     port: 8089,
     options: const ChannelOptions(
       credentials: ChannelCredentials.insecure(),

--- a/lib/platform/web/genus_config.dart
+++ b/lib/platform/web/genus_config.dart
@@ -1,5 +1,7 @@
 import 'package:grpc/grpc_web.dart';
+import 'package:ribn/constants/network_utils.dart';
+
 
 class PlatformGenusConfig {
-  static GrpcWebClientChannel channel = GrpcWebClientChannel.xhr(Uri.parse('http://35.226.176.100:8099'));
+  static GrpcWebClientChannel channel = GrpcWebClientChannel.xhr(Uri.parse('http://${NetworkUtils.privateIP}:8099'));
 }

--- a/lib/presentation/transaction_history/transaction_data_row/transaction_data_row.dart
+++ b/lib/presentation/transaction_history/transaction_data_row/transaction_data_row.dart
@@ -215,7 +215,7 @@ class _TransactionDataRowState extends State<TransactionDataRow> {
                 'timestamp': formattedDateAlternate,
                 'assetDetails': assetDetails,
                 'icon': renderAssetIcon(assetDetails?.icon),
-                'shortName': filteredAsset[0].assetCode.shortName.show.replaceAll('\x00', ''),
+                'shortName': filteredAsset.isNotEmpty ? filteredAsset[0].assetCode.shortName.show.replaceAll('\x00', '') : 'Unknown',
                 'transactionStatus': transactionStatus,
                 'transactionAmount':
                     '${transactionAmountForAssetTransfer()} ${formatAssetUnit(assetDetails?.unit ?? 'Unit')}',
@@ -264,7 +264,7 @@ class _TransactionDataRowState extends State<TransactionDataRow> {
                                   style: RibnToolkitTextStyles.extH3.copyWith(fontSize: 14),
                                 ),
                                 Text(
-                                  filteredAsset[0].assetCode.shortName.show.replaceAll('\x00', ''),
+                                  filteredAsset.isNotEmpty ? filteredAsset[0].assetCode.shortName.show.replaceAll('\x00', '') : 'Unknown',
                                   style: RibnToolkitTextStyles.assetLongNameStyle.copyWith(fontSize: 11),
                                 ),
                               ],


### PR DESCRIPTION
This primarily tackles RIBN's obscure error when switching networks on the transaction history page before having loaded the balance pages for those networks.

A small extra is that I've extracted the private IP into a central area (network_utils)