### PR TITLE
fix(RIBN-527): Rename Transactions Details to Activity Details

### DIFF
--- a/lib/constants/strings.dart
+++ b/lib/constants/strings.dart
@@ -285,7 +285,7 @@ Write down the each word in the exact order it is presented.''';
       '''Would you like to turn on biometrics for faster access to Ribn Wallet?\n 
 Ribn Wallet does not control the functionality of biometrics and does not have access to your biometrics information.''';
   static const String recentActivity = 'Recent Activity';
-  static const String transactionDetails = 'Activity details';
+  static const String transactionDetails = 'Transaction Details';
   static const String noActivityToReview = 'You currently have no wallet activity to review.';
   static const String noAssetsInWallet = 'You currently have no assets in your wallet.';
   static const String noAssetsAndBalanceInWallet = 'Want to add more assets to your wallet? ';


### PR DESCRIPTION
## Description

Fixes Rename Transactions Details to Activity Details

Fixes # ([issue](https://topl.atlassian.net/browse/RIBN-527))

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

-   [x] Manual Testing

## Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have added screenshots

<img width="1049" alt="Screenshot 2023-03-16 at 22 57 23" src="https://user-images.githubusercontent.com/25604678/225751102-257ecbea-851b-4670-82e2-7074cf65f53f.png">
